### PR TITLE
UIDeviceOrientation→UIInterfaceOrientationに変更

### DIFF
--- a/SpecialViewList/Component/Orientation/RotateScreenSampleViewController.swift
+++ b/SpecialViewList/Component/Orientation/RotateScreenSampleViewController.swift
@@ -41,8 +41,8 @@ class RotateScreenSampleViewController: UIViewController {
         UIAction { [weak self] _ in
             guard let self = self else { return }
             let rotatedDeviceOrientation = self.isPortrait
-                ? UIDeviceOrientation.landscapeRight
-                : UIDeviceOrientation.portrait
+                ? UIInterfaceOrientation.landscapeRight
+                : UIInterfaceOrientation.portrait
             self.updateOrientaiton(
                 deviceOrientation: rotatedDeviceOrientation
             )

--- a/SpecialViewList/Extenstion/UIDeviceExtension.swift
+++ b/SpecialViewList/Extenstion/UIDeviceExtension.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension UIDevice {
     static func setOrientation(
-        deviceOrientation: UIDeviceOrientation
+        deviceOrientation: UIInterfaceOrientation
     ) {
         current.setValue(
             deviceOrientation.rawValue,

--- a/SpecialViewList/Extenstion/UIViewControllerExtension.swift
+++ b/SpecialViewList/Extenstion/UIViewControllerExtension.swift
@@ -10,7 +10,7 @@ extension UIViewController {
     }
     
     func updateOrientaiton(
-        deviceOrientation: UIDeviceOrientation
+        deviceOrientation: UIInterfaceOrientation
     ) {
         if #available(iOS 16.0, *) {
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene


### PR DESCRIPTION
# 概要
UIDeviceOrientation→UIInterfaceOrientationに変更

▼UIInterfaceOrientation
UIの向きを指定する定数
https://developer.apple.com/documentation/uikit/uiinterfaceorientation

```UIInterfaceOrientation.swift
public enum UIInterfaceOrientation : Int {
    case unknown //0 
    case portrait //1 //普通の縦向き
    case portraitUpsideDown //2 //逆さ向き
    case landscapeLeft //3 //homeボタンが左
    case landscapeRight //4 //homeボタンが右
}
```

▼UIDeviceOrientation
デバイスの物理的な向きを表す定数
https://developer.apple.com/documentation/uikit/uideviceorientation

```UIDeviceOrientation.swift
public enum UIDeviceOrientation : Int {
    case unknown //0 
    case portrait //1 //普通の縦向き
    case portraitUpsideDown //2 //逆さ向き
    case landscapeLeft //3 //homeボタンが右
    case landscapeRight //4 //homeボタンが左
    case faceUp //5 //地面に平行向き//スクリーンが上
    case faceDown //6 //地面に平行向き//スクリーンが下
}
```