### PR TITLE
UIHostingControllerを使用してSwiftUIのViewを表示する画面の作成

### DIFF
--- a/SpecialViewList.xcodeproj/project.pbxproj
+++ b/SpecialViewList.xcodeproj/project.pbxproj
@@ -23,6 +23,17 @@
 		1673A7B328C4D19C00F9BF77 /* CellAnimationHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1673A7B228C4D19C00F9BF77 /* CellAnimationHeaderView.xib */; };
 		1673A7B628C573CC00F9BF77 /* CellAnimationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1673A7B428C573CC00F9BF77 /* CellAnimationTableViewCell.swift */; };
 		1673A7B728C573CC00F9BF77 /* CellAnimationTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1673A7B528C573CC00F9BF77 /* CellAnimationTableViewCell.xib */; };
+		16CAA19928DC94DF00A5108B /* HostingControllerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA19728DC94DF00A5108B /* HostingControllerViewController.swift */; };
+		16CAA19A28DC94DF00A5108B /* HostingControllerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 16CAA19828DC94DF00A5108B /* HostingControllerViewController.xib */; };
+		16CAA19C28DC976500A5108B /* HostingBaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA19B28DC976500A5108B /* HostingBaseView.swift */; };
+		16CAA19E28DC98E800A5108B /* HostingControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA19D28DC98E800A5108B /* HostingControllerViewModel.swift */; };
+		16CAA1A428DC9A0F00A5108B /* UDFViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA1A128DC9A0F00A5108B /* UDFViewModel.swift */; };
+		16CAA1A528DC9A0F00A5108B /* ActionSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA1A228DC9A0F00A5108B /* ActionSender.swift */; };
+		16CAA1A628DC9A0F00A5108B /* StateHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA1A328DC9A0F00A5108B /* StateHolder.swift */; };
+		16CAA1AB28DCADBB00A5108B /* NextHostingControllerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA1A928DCADBB00A5108B /* NextHostingControllerViewController.swift */; };
+		16CAA1AC28DCADBB00A5108B /* NextHostingControllerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 16CAA1AA28DCADBB00A5108B /* NextHostingControllerViewController.xib */; };
+		16CAA1AE28DCAF5800A5108B /* NextHostingBaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA1AD28DCAF5800A5108B /* NextHostingBaseView.swift */; };
+		16CAA1B028DCB30200A5108B /* NextHostingControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA1AF28DCB30200A5108B /* NextHostingControllerViewModel.swift */; };
 		CA36A78427CE4F6A003B9140 /* SubtitleInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA36A78327CE4F6A003B9140 /* SubtitleInfo.swift */; };
 		CA36A78827CE5A99003B9140 /* SubtitlePlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA36A78627CE5A99003B9140 /* SubtitlePlayerViewController.swift */; };
 		CA36A78927CE5A99003B9140 /* SubtitlePlayerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CA36A78727CE5A99003B9140 /* SubtitlePlayerViewController.xib */; };
@@ -116,6 +127,17 @@
 		1673A7B228C4D19C00F9BF77 /* CellAnimationHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CellAnimationHeaderView.xib; sourceTree = "<group>"; };
 		1673A7B428C573CC00F9BF77 /* CellAnimationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellAnimationTableViewCell.swift; sourceTree = "<group>"; };
 		1673A7B528C573CC00F9BF77 /* CellAnimationTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CellAnimationTableViewCell.xib; sourceTree = "<group>"; };
+		16CAA19728DC94DF00A5108B /* HostingControllerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostingControllerViewController.swift; sourceTree = "<group>"; };
+		16CAA19828DC94DF00A5108B /* HostingControllerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HostingControllerViewController.xib; sourceTree = "<group>"; };
+		16CAA19B28DC976500A5108B /* HostingBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostingBaseView.swift; sourceTree = "<group>"; };
+		16CAA19D28DC98E800A5108B /* HostingControllerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostingControllerViewModel.swift; sourceTree = "<group>"; };
+		16CAA1A128DC9A0F00A5108B /* UDFViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UDFViewModel.swift; sourceTree = "<group>"; };
+		16CAA1A228DC9A0F00A5108B /* ActionSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSender.swift; sourceTree = "<group>"; };
+		16CAA1A328DC9A0F00A5108B /* StateHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateHolder.swift; sourceTree = "<group>"; };
+		16CAA1A928DCADBB00A5108B /* NextHostingControllerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextHostingControllerViewController.swift; sourceTree = "<group>"; };
+		16CAA1AA28DCADBB00A5108B /* NextHostingControllerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NextHostingControllerViewController.xib; sourceTree = "<group>"; };
+		16CAA1AD28DCAF5800A5108B /* NextHostingBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextHostingBaseView.swift; sourceTree = "<group>"; };
+		16CAA1AF28DCB30200A5108B /* NextHostingControllerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextHostingControllerViewModel.swift; sourceTree = "<group>"; };
 		CA36A78327CE4F6A003B9140 /* SubtitleInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleInfo.swift; sourceTree = "<group>"; };
 		CA36A78627CE5A99003B9140 /* SubtitlePlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitlePlayerViewController.swift; sourceTree = "<group>"; };
 		CA36A78727CE5A99003B9140 /* SubtitlePlayerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SubtitlePlayerViewController.xib; sourceTree = "<group>"; };
@@ -240,6 +262,39 @@
 			path = TableViewCellAnimation;
 			sourceTree = "<group>";
 		};
+		16CAA19628DC93C100A5108B /* HostingController */ = {
+			isa = PBXGroup;
+			children = (
+				16CAA1A828DCAD6F00A5108B /* NextHostingController */,
+				16CAA19728DC94DF00A5108B /* HostingControllerViewController.swift */,
+				16CAA19828DC94DF00A5108B /* HostingControllerViewController.xib */,
+				16CAA19B28DC976500A5108B /* HostingBaseView.swift */,
+				16CAA19D28DC98E800A5108B /* HostingControllerViewModel.swift */,
+			);
+			path = HostingController;
+			sourceTree = "<group>";
+		};
+		16CAA1A728DC9A1E00A5108B /* UDF */ = {
+			isa = PBXGroup;
+			children = (
+				16CAA1A228DC9A0F00A5108B /* ActionSender.swift */,
+				16CAA1A328DC9A0F00A5108B /* StateHolder.swift */,
+				16CAA1A128DC9A0F00A5108B /* UDFViewModel.swift */,
+			);
+			path = UDF;
+			sourceTree = "<group>";
+		};
+		16CAA1A828DCAD6F00A5108B /* NextHostingController */ = {
+			isa = PBXGroup;
+			children = (
+				16CAA1A928DCADBB00A5108B /* NextHostingControllerViewController.swift */,
+				16CAA1AA28DCADBB00A5108B /* NextHostingControllerViewController.xib */,
+				16CAA1AD28DCAF5800A5108B /* NextHostingBaseView.swift */,
+				16CAA1AF28DCB30200A5108B /* NextHostingControllerViewModel.swift */,
+			);
+			path = NextHostingController;
+			sourceTree = "<group>";
+		};
 		CA36A78527CE59CE003B9140 /* SubtitlePlayerView */ = {
 			isa = PBXGroup;
 			children = (
@@ -306,6 +361,7 @@
 		CA5F0A1D27B5E4F70021E1FD /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				16CAA1A728DC9A1E00A5108B /* UDF */,
 				CA36A79D27CFB1C4003B9140 /* Player */,
 				CA5F0A2427B5E5290021E1FD /* Views */,
 			);
@@ -326,6 +382,7 @@
 		CA5F0A2527B5E5640021E1FD /* Component */ = {
 			isa = PBXGroup;
 			children = (
+				16CAA19628DC93C100A5108B /* HostingController */,
 				1635CDE528D989F400ADF7A6 /* Orientation */,
 				1635CDC528C8E21000ADF7A6 /* SomeAutoVideoPlayer */,
 				1673A7A928C4CE5000F9BF77 /* TableViewCellAnimation */,
@@ -513,6 +570,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				16CAA19A28DC94DF00A5108B /* HostingControllerViewController.xib in Resources */,
 				1673A7B328C4D19C00F9BF77 /* CellAnimationHeaderView.xib in Resources */,
 				CA3F555327C6050600D6CAC2 /* LinkLabelView.xib in Resources */,
 				CAAAA90728B76DAE003903F8 /* ChoiceFormViewController.xib in Resources */,
@@ -530,6 +588,7 @@
 				1635CDD128CC319D00ADF7A6 /* AVPlayerViewControllerView.xib in Resources */,
 				CA946107284B145100EBF5FE /* movie5.mp4 in Resources */,
 				CA5F0A2927B5E8E40021E1FD /* SpecialViewListViewController.xib in Resources */,
+				16CAA1AC28DCADBB00A5108B /* NextHostingControllerViewController.xib in Resources */,
 				CA3F554D27C602B300D6CAC2 /* LinkLabelViewController.xib in Resources */,
 				CAAAA90D28B76F1A003903F8 /* ChoiceFormView.xib in Resources */,
 				CA36A79127CE5D94003B9140 /* SubtitleTableViewCell.xib in Resources */,
@@ -557,15 +616,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				16CAA1A528DC9A0F00A5108B /* ActionSender.swift in Sources */,
 				1673A7AB28C4CE8700F9BF77 /* TableViewCellAnimationViewModel.swift in Sources */,
 				CA36A78427CE4F6A003B9140 /* SubtitleInfo.swift in Sources */,
 				CACFFAC62848B3B700D920FF /* VideoCollectionView.swift in Sources */,
 				CA5F0ACB27B645DA0021E1FD /* ItemContent.swift in Sources */,
+				16CAA1AE28DCAF5800A5108B /* NextHostingBaseView.swift in Sources */,
 				CA36A79F27CFB1DF003B9140 /* AudioPlayer.swift in Sources */,
 				CA5F0A2327B5E5250021E1FD /* NibOwnerLoadable.swift in Sources */,
 				1673A7B628C573CC00F9BF77 /* CellAnimationTableViewCell.swift in Sources */,
 				CA3F555127C604FB00D6CAC2 /* LinkLabelView.swift in Sources */,
 				1673A7AE28C4CF7700F9BF77 /* TableViewCellAnimationViewController.swift in Sources */,
+				16CAA19928DC94DF00A5108B /* HostingControllerViewController.swift in Sources */,
 				1635CDE828D98AE800ADF7A6 /* RotateScreenSampleViewController.swift in Sources */,
 				CA5F0A2227B5E5250021E1FD /* NibLoadable.swift in Sources */,
 				1635CDCB28C8E25A00ADF7A6 /* DefaultAVPlayerViewModel.swift in Sources */,
@@ -592,14 +654,18 @@
 				CA5F0A1B27B5E4E00021E1FD /* UICollectionViewExtension.swift in Sources */,
 				CA5F0A2127B5E5250021E1FD /* NibBundler.swift in Sources */,
 				1635CDC828C8E23500ADF7A6 /* DefaultAVPlayerViewController.swift in Sources */,
+				16CAA1A428DC9A0F00A5108B /* UDFViewModel.swift in Sources */,
 				CAABE3D227BC6D3000A5D396 /* AutoFlowedTitleViewController.swift in Sources */,
 				CA5F0A2827B5E8E40021E1FD /* SpecialViewListViewController.swift in Sources */,
+				16CAA19C28DC976500A5108B /* HostingBaseView.swift in Sources */,
 				CA5F0AB727B5FB480021E1FD /* SpecialViewListTableViewCell.swift in Sources */,
 				CACFFACA2848B45500D920FF /* VideoPreviewView.swift in Sources */,
 				CAAAA90628B76DAE003903F8 /* ChoiceFormViewController.swift in Sources */,
 				CAAAA90928B76E01003903F8 /* ChoiceFormViewModel.swift in Sources */,
 				CA3F555527C6083600D6CAC2 /* LabelLinkTapGesture.swift in Sources */,
+				16CAA1B028DCB30200A5108B /* NextHostingControllerViewModel.swift in Sources */,
 				CA5F0ABF27B634EE0021E1FD /* Grid3x3ViewController.swift in Sources */,
+				16CAA1AB28DCADBB00A5108B /* NextHostingControllerViewController.swift in Sources */,
 				CA5F0AD327B7770E0021E1FD /* SpecialViewList.swift in Sources */,
 				CA5F0AC627B63E780021E1FD /* Grid3x3ItemView.swift in Sources */,
 				CAABE3D727BC6F2200A5D396 /* AutoFlowedTitleView.swift in Sources */,
@@ -610,7 +676,9 @@
 				CA36A79027CE5D94003B9140 /* SubtitleTableViewCell.swift in Sources */,
 				1635CDEB28DACF7900ADF7A6 /* UIDeviceExtension.swift in Sources */,
 				CA5F0AC227B635760021E1FD /* Grid3x3View.swift in Sources */,
+				16CAA1A628DC9A0F00A5108B /* StateHolder.swift in Sources */,
 				CA36A79327CE60C8003B9140 /* SubtitlePlayerViewModel.swift in Sources */,
+				16CAA19E28DC98E800A5108B /* HostingControllerViewModel.swift in Sources */,
 				CA5F0ACD27B646020021E1FD /* Grid3x3ItemTapGesture.swift in Sources */,
 				CAAAA90F28B7753F003903F8 /* ChoiceView.swift in Sources */,
 			);

--- a/SpecialViewList/Component/HostingController/HostingBaseView.swift
+++ b/SpecialViewList/Component/HostingController/HostingBaseView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct HostingBaseView: View {
+    
+    @ObservedObject private var viewModel: HostingControllerViewModel
+    
+    init(viewModel: HostingControllerViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    var body: some View {
+        ZStack(alignment: .top) {
+            Color.white.ignoresSafeArea()
+            VStack(spacing: 16) {
+                Text(viewModel.state.name)
+                TextField("名前を入力してください。", text: $viewModel.state.name)
+                    .padding()
+                    .frame(height: 56)
+                    .overlay(
+                        RoundedRectangle(
+                            cornerRadius: 16
+                        ).stroke(.black, lineWidth: 1)
+                    )
+                Button {
+                    viewModel.send(.didTapClearText)
+                } label: {
+                    Text("テキストをクリアする")
+                }
+                Button {
+                    viewModel.send(.didTapOpenNextHostingBaseView)
+                } label: {
+                    Text("次の画面に遷移")
+                }
+            }.padding(.horizontal, 16)
+        }
+    }
+}
+
+struct HostingBaseView_Previews: PreviewProvider {
+    static var previews: some View {
+        HostingBaseView(viewModel: HostingControllerViewModel())
+    }
+}

--- a/SpecialViewList/Component/HostingController/HostingControllerViewController.swift
+++ b/SpecialViewList/Component/HostingController/HostingControllerViewController.swift
@@ -1,0 +1,37 @@
+import UIKit
+import SwiftUI
+import Combine
+
+class HostingControllerViewController: UIHostingController<HostingBaseView> {
+
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(viewModel: HostingControllerViewModel) {
+        super.init(
+            rootView: HostingBaseView(
+                viewModel: viewModel
+            )
+        )
+        
+        viewModel.$state.map(\.transitionScreen)
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue:  { [weak self] transitionScreen in
+                switch transitionScreen {
+                case .nextHostingBaseView:
+                    let controller = NextHostingControllerViewController(
+                        viewModel: NextHostingControllerViewModel()
+                    )
+                    let navigationController = UINavigationController()
+                    navigationController.viewControllers = [controller]
+                    self?.present(navigationController, animated: true)
+                }
+            })
+            .store(in: &cancellables)
+    }
+    
+    @available(*, unavailable)
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/SpecialViewList/Component/HostingController/HostingControllerViewController.xib
+++ b/SpecialViewList/Component/HostingController/HostingControllerViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="HostingControllerViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/SpecialViewList/Component/HostingController/HostingControllerViewModel.swift
+++ b/SpecialViewList/Component/HostingController/HostingControllerViewModel.swift
@@ -1,0 +1,32 @@
+import Combine
+
+class HostingControllerViewModel: ObservableObject, UDFViewModel {
+    enum Action {
+        case didTapClearText
+        case didTapOpenNextHostingBaseView
+    }
+    
+    enum HostingBaseTransitionScreen {
+        case nextHostingBaseView
+    }
+    
+    struct State: Equatable {
+        var name: String = ""
+        var transitionScreen: HostingBaseTransitionScreen?
+    }
+    
+    @Published var state: State
+    
+    init(state: State = State()) {
+        self.state = state
+    }
+    
+    func send(_ action: Action) {
+        switch action {
+        case .didTapClearText:
+            state.name = ""
+        case .didTapOpenNextHostingBaseView:
+            state.transitionScreen = .nextHostingBaseView
+        }
+    }
+}

--- a/SpecialViewList/Component/HostingController/NextHostingController/NextHostingBaseView.swift
+++ b/SpecialViewList/Component/HostingController/NextHostingController/NextHostingBaseView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct NextHostingBaseView: View {
+    @ObservedObject private var viewModel: NextHostingControllerViewModel
+    
+    init(viewModel: NextHostingControllerViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    var body: some View {
+        ZStack(alignment: .top) {
+            Color.white.ignoresSafeArea()
+            VStack(spacing: 16) {
+                Text("次の画面")
+                Button {
+                    viewModel.send(.dismissView)
+                } label: {
+                    Text("閉じる")
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+    }
+}
+
+struct NextHostingBaseView_Previews: PreviewProvider {
+    static var previews: some View {
+        NextHostingBaseView(
+            viewModel: NextHostingControllerViewModel()
+        )
+    }
+}

--- a/SpecialViewList/Component/HostingController/NextHostingController/NextHostingControllerViewController.swift
+++ b/SpecialViewList/Component/HostingController/NextHostingController/NextHostingControllerViewController.swift
@@ -1,0 +1,37 @@
+import UIKit
+import SwiftUI
+import Combine
+
+class NextHostingControllerViewController: UIHostingController<NextHostingBaseView> {
+    
+    private var cancellables = Set<AnyCancellable>()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    init(viewModel: NextHostingControllerViewModel) {
+        super.init(
+            rootView: NextHostingBaseView(
+                viewModel: viewModel
+            )
+        )
+        
+        viewModel.$state.map(\.transitionScreen)
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue:  { [weak self] transitionScreen in
+                switch transitionScreen {
+                case .dismissView:
+                    self?.dismiss(animated: true)
+                }
+            })
+            .store(in: &cancellables)
+    }
+    
+    
+    @available(*, unavailable)
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/SpecialViewList/Component/HostingController/NextHostingController/NextHostingControllerViewController.xib
+++ b/SpecialViewList/Component/HostingController/NextHostingController/NextHostingControllerViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NextHostingControllerViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/SpecialViewList/Component/HostingController/NextHostingController/NextHostingControllerViewModel.swift
+++ b/SpecialViewList/Component/HostingController/NextHostingController/NextHostingControllerViewModel.swift
@@ -1,0 +1,28 @@
+import Combine
+
+class NextHostingControllerViewModel: ObservableObject, UDFViewModel {
+    enum Action {
+        case dismissView
+    }
+    
+    enum NextHostingBaseTransitionScreen {
+        case dismissView
+    }
+    
+    struct State: Equatable {
+        var transitionScreen: NextHostingBaseTransitionScreen?
+    }
+    
+    @Published var state: State
+    
+    init(state: State = State()) {
+        self.state = state
+    }
+    
+    func send(_ action: Action) {
+        switch action {
+        case .dismissView:
+            state.transitionScreen = .dismissView
+        }
+    }
+}

--- a/SpecialViewList/Component/SpecialViewList/SpecialViewList.swift
+++ b/SpecialViewList/Component/SpecialViewList/SpecialViewList.swift
@@ -1,9 +1,10 @@
 enum SpecialViewList {
     enum Section: CaseIterable {
-        case customView
+        case customView, viewController
         
         var title: String {
             switch self {
+            case .viewController: return "ViewController"
             case .customView: return "CustomView"
             }
         }
@@ -22,12 +23,19 @@ enum SpecialViewList {
                     .defaultAVPlayerView,
                     .orientation
                 ]
+            case .viewController:
+                return [
+                    .hostingController
+                ]
             }
         }
     }
 
     enum Item: CaseIterable {
+        // customView
         case grid3x3, autoFlowedTitle, linkLabel, subtitlePlayer, videoCollection, choiceForm, tableViewCellAnimation, defaultAVPlayerView, orientation
+        // viewController
+        case hostingController
         
         var title: String {
             switch self {
@@ -49,6 +57,8 @@ enum SpecialViewList {
                 return "動画が自動で再生されるview"
             case .orientation:
                 return "回転に対応するView"
+            case .hostingController:
+                return "SwiftUIのViewをUIKitのBaseのVCに表示する画面"
             }
         }
         
@@ -73,6 +83,8 @@ enum SpecialViewList {
                 return "AVKitのAVPlayerViewControllerを使用した方法で動画を再生するView"
             case .orientation:
                 return "回転したときのViewの動きを確認するためView"
+            case .hostingController:
+                return "UIHostingViewControllerを使用して、SwiftUIのViewをUIKitのVCに表示するための画面"
             }
         }
     }

--- a/SpecialViewList/Component/SpecialViewList/SpecialViewListViewController.swift
+++ b/SpecialViewList/Component/SpecialViewList/SpecialViewListViewController.swift
@@ -104,6 +104,8 @@ class SpecialViewListViewController: UIViewController {
             let controller = RotateScreenSampleViewController()
             controller.modalPresentationStyle = .fullScreen
             present(controller, animated: true)
+        case .hostingController:
+            break
         }
     }
 }
@@ -122,27 +124,20 @@ extension SpecialViewListViewController: UITableViewDataSource {
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
         let listSection = viewModel.listSections[indexPath.section]
-        switch listSection {
-        case .customView:
-            let item = listSection.items[indexPath.row]
-            let cell = tableView.dequeueReusableCell(for: indexPath) as SpecialViewListTableViewCell
-            cell.setup(
-                title: item.title,
-                discription: item.discription
-            )
-            return cell
-        }
+        let item = listSection.items[indexPath.row]
+        let cell = tableView.dequeueReusableCell(for: indexPath) as SpecialViewListTableViewCell
+        cell.setup(
+            title: item.title,
+            discription: item.discription
+        )
+        return cell
     }
     
     func tableView(
         _ tableView: UITableView,
         titleForHeaderInSection section: Int
     ) -> String? {
-        let listSection = viewModel.listSections[section]
-        switch listSection {
-        case .customView:
-            return listSection.title
-        }
+        viewModel.listSections[section].title
     }
 }
 
@@ -156,11 +151,8 @@ extension SpecialViewListViewController: UITableViewDelegate {
         }
         
         let listSection = viewModel.listSections[indexPath.section]
-        switch listSection {
-        case .customView:
-            openView(
-                listItem: listSection.items[indexPath.row]
-            )
-        }
+        openView(
+            listItem: listSection.items[indexPath.row]
+        )
     }
 }

--- a/SpecialViewList/Component/SpecialViewList/SpecialViewListViewController.swift
+++ b/SpecialViewList/Component/SpecialViewList/SpecialViewListViewController.swift
@@ -105,7 +105,14 @@ class SpecialViewListViewController: UIViewController {
             controller.modalPresentationStyle = .fullScreen
             present(controller, animated: true)
         case .hostingController:
-            break
+            let viewModel = HostingControllerViewModel()
+            let controller = HostingControllerViewController(
+                viewModel: viewModel
+            )
+            navigationController?.pushViewController(
+                controller,
+                animated: true
+            )
         }
     }
 }

--- a/SpecialViewList/Foundation/UDF/ActionSender.swift
+++ b/SpecialViewList/Foundation/UDF/ActionSender.swift
@@ -1,0 +1,5 @@
+protocol ActionSender {
+    associatedtype Action
+
+    func send(_ action: Action)
+}

--- a/SpecialViewList/Foundation/UDF/StateHolder.swift
+++ b/SpecialViewList/Foundation/UDF/StateHolder.swift
@@ -1,0 +1,5 @@
+protocol StateHolder: AnyObject {
+    associatedtype State: Equatable
+
+    var state: State { get }
+}

--- a/SpecialViewList/Foundation/UDF/UDFViewModel.swift
+++ b/SpecialViewList/Foundation/UDF/UDFViewModel.swift
@@ -1,0 +1,1 @@
+protocol UDFViewModel: ActionSender, StateHolder {}


### PR DESCRIPTION
# 概要
UIHostingControllerを使用してSwiftUIのViewを表示する画面の作成

## 詳細
- ViewとVMが単方向フローになるようにUDFViewModelプロトコルを追加
- UIHostingControllerを使用してSwiftUIのViewをVCのrootViewに設定して表示
- 遷移周りもVCで行うようにVMにTransitionScreenを定義してStateに持たせるようにしてVCでバインドさせる