### PR TITLE
UICollectionViewCompositionalLayoutを用いたCollectionViewのHeaderを実装

### DIFF
--- a/SpecialViewList.xcodeproj/project.pbxproj
+++ b/SpecialViewList.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		161383F52913E36000A4E787 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161383F42913E36000A4E787 /* Sample.swift */; };
 		161383F72913E37F00A4E787 /* CollectionContentDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161383F62913E37F00A4E787 /* CollectionContentDetail.swift */; };
 		161383F9291400E900A4E787 /* CollectionViewCompositionalLayoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161383F8291400E900A4E787 /* CollectionViewCompositionalLayoutViewModel.swift */; };
+		16334C3029192C06002D2FEE /* UIBarButtonItemExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16334C2F29192C06002D2FEE /* UIBarButtonItemExtension.swift */; };
+		16334C3229192C46002D2FEE /* SFSymbolType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16334C3129192C46002D2FEE /* SFSymbolType.swift */; };
+		16334C3429192DA1002D2FEE /* UIImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16334C3329192DA1002D2FEE /* UIImageExtension.swift */; };
 		1635CDC828C8E23500ADF7A6 /* DefaultAVPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1635CDC628C8E23500ADF7A6 /* DefaultAVPlayerViewController.swift */; };
 		1635CDC928C8E23500ADF7A6 /* DefaultAVPlayerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1635CDC728C8E23500ADF7A6 /* DefaultAVPlayerViewController.xib */; };
 		1635CDCB28C8E25A00ADF7A6 /* DefaultAVPlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1635CDCA28C8E25A00ADF7A6 /* DefaultAVPlayerViewModel.swift */; };
@@ -145,6 +148,9 @@
 		161383F42913E36000A4E787 /* Sample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sample.swift; sourceTree = "<group>"; };
 		161383F62913E37F00A4E787 /* CollectionContentDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionContentDetail.swift; sourceTree = "<group>"; };
 		161383F8291400E900A4E787 /* CollectionViewCompositionalLayoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewCompositionalLayoutViewModel.swift; sourceTree = "<group>"; };
+		16334C2F29192C06002D2FEE /* UIBarButtonItemExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtension.swift; sourceTree = "<group>"; };
+		16334C3129192C46002D2FEE /* SFSymbolType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbolType.swift; sourceTree = "<group>"; };
+		16334C3329192DA1002D2FEE /* UIImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtension.swift; sourceTree = "<group>"; };
 		1635CDC628C8E23500ADF7A6 /* DefaultAVPlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAVPlayerViewController.swift; sourceTree = "<group>"; };
 		1635CDC728C8E23500ADF7A6 /* DefaultAVPlayerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DefaultAVPlayerViewController.xib; sourceTree = "<group>"; };
 		1635CDCA28C8E25A00ADF7A6 /* DefaultAVPlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAVPlayerViewModel.swift; sourceTree = "<group>"; };
@@ -470,6 +476,8 @@
 				CA5F0A1A27B5E4E00021E1FD /* UITableViewExtension.swift */,
 				1635CDEA28DACF7900ADF7A6 /* UIDeviceExtension.swift */,
 				1635CDEC28DAD3BE00ADF7A6 /* UIViewControllerExtension.swift */,
+				16334C2F29192C06002D2FEE /* UIBarButtonItemExtension.swift */,
+				16334C3329192DA1002D2FEE /* UIImageExtension.swift */,
 			);
 			path = Extenstion;
 			sourceTree = "<group>";
@@ -480,6 +488,7 @@
 				16CAA1A728DC9A1E00A5108B /* UDF */,
 				CA36A79D27CFB1C4003B9140 /* Player */,
 				CA5F0A2427B5E5290021E1FD /* Views */,
+				16334C3129192C46002D2FEE /* SFSymbolType.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -751,6 +760,7 @@
 			files = (
 				16CAA1A528DC9A0F00A5108B /* ActionSender.swift in Sources */,
 				1673A7AB28C4CE8700F9BF77 /* TableViewCellAnimationViewModel.swift in Sources */,
+				16334C3229192C46002D2FEE /* SFSymbolType.swift in Sources */,
 				CA36A78427CE4F6A003B9140 /* SubtitleInfo.swift in Sources */,
 				CACFFAC62848B3B700D920FF /* VideoCollectionView.swift in Sources */,
 				CA5F0ACB27B645DA0021E1FD /* ItemContent.swift in Sources */,
@@ -796,8 +806,10 @@
 				CA5F0A1827B5E4D30021E1FD /* NSObjectExtension.swift in Sources */,
 				CA5F0A1B27B5E4E00021E1FD /* UICollectionViewExtension.swift in Sources */,
 				161383EA2913608300A4E787 /* CollectionViewCompositionalLayoutViewController.swift in Sources */,
+				16334C3029192C06002D2FEE /* UIBarButtonItemExtension.swift in Sources */,
 				CA5F0A2127B5E5250021E1FD /* NibBundler.swift in Sources */,
 				1635CDC828C8E23500ADF7A6 /* DefaultAVPlayerViewController.swift in Sources */,
+				16334C3429192DA1002D2FEE /* UIImageExtension.swift in Sources */,
 				16CAA1A428DC9A0F00A5108B /* UDFViewModel.swift in Sources */,
 				CAABE3D227BC6D3000A5D396 /* AutoFlowedTitleViewController.swift in Sources */,
 				CA5F0A2827B5E8E40021E1FD /* SpecialViewListViewController.swift in Sources */,

--- a/SpecialViewList.xcodeproj/project.pbxproj
+++ b/SpecialViewList.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		16CAA1B028DCB30200A5108B /* NextHostingControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA1AF28DCB30200A5108B /* NextHostingControllerViewModel.swift */; };
 		16CAA1B428E0186300A5108B /* LoginByConcurrencyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CAA1B228E0186300A5108B /* LoginByConcurrencyViewController.swift */; };
 		16CAA1B528E0186300A5108B /* LoginByConcurrencyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 16CAA1B328E0186300A5108B /* LoginByConcurrencyViewController.xib */; };
+		16FCFC7B2917E6060061C97B /* CollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FCFC7A2917E6060061C97B /* CollectionHeaderView.swift */; };
+		16FCFC7D2917E7910061C97B /* CollectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 16FCFC7C2917E7910061C97B /* CollectionHeaderView.xib */; };
 		CA36A78427CE4F6A003B9140 /* SubtitleInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA36A78327CE4F6A003B9140 /* SubtitleInfo.swift */; };
 		CA36A78827CE5A99003B9140 /* SubtitlePlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA36A78627CE5A99003B9140 /* SubtitlePlayerViewController.swift */; };
 		CA36A78927CE5A99003B9140 /* SubtitlePlayerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CA36A78727CE5A99003B9140 /* SubtitlePlayerViewController.xib */; };
@@ -184,6 +186,8 @@
 		16CAA1AF28DCB30200A5108B /* NextHostingControllerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextHostingControllerViewModel.swift; sourceTree = "<group>"; };
 		16CAA1B228E0186300A5108B /* LoginByConcurrencyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginByConcurrencyViewController.swift; sourceTree = "<group>"; };
 		16CAA1B328E0186300A5108B /* LoginByConcurrencyViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoginByConcurrencyViewController.xib; sourceTree = "<group>"; };
+		16FCFC7A2917E6060061C97B /* CollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionHeaderView.swift; sourceTree = "<group>"; };
+		16FCFC7C2917E7910061C97B /* CollectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectionHeaderView.xib; sourceTree = "<group>"; };
 		CA36A78327CE4F6A003B9140 /* SubtitleInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleInfo.swift; sourceTree = "<group>"; };
 		CA36A78627CE5A99003B9140 /* SubtitlePlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitlePlayerViewController.swift; sourceTree = "<group>"; };
 		CA36A78727CE5A99003B9140 /* SubtitlePlayerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SubtitlePlayerViewController.xib; sourceTree = "<group>"; };
@@ -335,6 +339,8 @@
 				161383ED2913778D00A4E787 /* ImageCollectionViewCell.xib */,
 				161383F02913794500A4E787 /* OverviewWithToggleCollectionViewCell.swift */,
 				161383F12913794500A4E787 /* OverviewWithToggleCollectionViewCell.xib */,
+				16FCFC7A2917E6060061C97B /* CollectionHeaderView.swift */,
+				16FCFC7C2917E7910061C97B /* CollectionHeaderView.xib */,
 			);
 			path = CollectionView;
 			sourceTree = "<group>";
@@ -718,6 +724,7 @@
 				1673A7B728C573CC00F9BF77 /* CellAnimationTableViewCell.xib in Resources */,
 				1658D81128F777F200E88878 /* BottomUpKeyboardHeightViewController.xib in Resources */,
 				CA36A7A227CFBC7F003B9140 /* audio_tmp_30.m4a in Resources */,
+				16FCFC7D2917E7910061C97B /* CollectionHeaderView.xib in Resources */,
 				1658D80528F6A83D00E88878 /* VideoPreviewCollectionViewCell.xib in Resources */,
 				CA664DC327B5E31D0083D686 /* Assets.xcassets in Resources */,
 				1635CDE928D98AE800ADF7A6 /* RotateScreenSampleViewController.xib in Resources */,
@@ -763,6 +770,7 @@
 				1635CDCB28C8E25A00ADF7A6 /* DefaultAVPlayerViewModel.swift in Sources */,
 				1635CDED28DAD3BE00ADF7A6 /* UIViewControllerExtension.swift in Sources */,
 				CA664DBA27B5E31C0083D686 /* AppDelegate.swift in Sources */,
+				16FCFC7B2917E6060061C97B /* CollectionHeaderView.swift in Sources */,
 				CA36A78B27CE5AC7003B9140 /* SubtitlePlayerView.swift in Sources */,
 				CA9460F5284A049400EBF5FE /* VideoView.swift in Sources */,
 				CA5F0AD127B7769E0021E1FD /* Grid3x3ViewModel.swift in Sources */,

--- a/SpecialViewList/Component/CollectionViewCompositionalLayout/CollectionViewCompositionalLayoutViewController.swift
+++ b/SpecialViewList/Component/CollectionViewCompositionalLayout/CollectionViewCompositionalLayoutViewController.swift
@@ -4,6 +4,11 @@ class CollectionViewCompositionalLayoutViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView! {
         didSet {
             collectionView.dataSource = self
+            collectionView.register(
+                UINib(nibName: CollectionHeaderView.className, bundle: nil),
+                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+                withReuseIdentifier: CollectionHeaderView.className
+            )
             let nibs = [
                 ContentCollectionViewCell.self,
                 ImageCollectionViewCell.self,
@@ -17,6 +22,9 @@ class CollectionViewCompositionalLayoutViewController: UIViewController {
     }
     
     private var collectionLayout: UICollectionViewCompositionalLayout {
+        let config = UICollectionViewCompositionalLayoutConfiguration()
+        config.scrollDirection = .vertical
+        
         let sectionProvider = { [weak self] (section: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
             guard let self else { return nil }
             let sectionType = self.viewModel.state.sections[section]
@@ -66,6 +74,15 @@ class CollectionViewCompositionalLayoutViewController: UIViewController {
                 let layoutSection = NSCollectionLayoutSection(group: group)
                 return layoutSection
             case .content:
+                let headerSize = NSCollectionLayoutSize(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .absolute(56)
+                )
+                let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
+                    layoutSize: headerSize,
+                    elementKind: UICollectionView.elementKindSectionHeader,
+                    alignment: .top
+                )
                 let itemSize = NSCollectionLayoutSize(
                     widthDimension: .fractionalWidth(1),
                     heightDimension: .absolute(44)
@@ -77,12 +94,14 @@ class CollectionViewCompositionalLayoutViewController: UIViewController {
                     count: 1
                 )
                 let layoutSection = NSCollectionLayoutSection(group: group)
+                layoutSection.boundarySupplementaryItems = [sectionHeader]
                 return layoutSection
             }
         }
         
         return UICollectionViewCompositionalLayout(
-            sectionProvider: sectionProvider
+            sectionProvider: sectionProvider,
+            configuration: config
         )
     }
     
@@ -159,6 +178,29 @@ extension CollectionViewCompositionalLayoutViewController: UICollectionViewDataS
             let title = viewModel.state.contentDetail.contents[indexPath.item].title
             cell.set(titleText: title)
             return cell
+        }
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionReusableView {
+        let sectionType = viewModel.state.sections[indexPath.section]
+        switch sectionType {
+        case .content:
+            guard let headerView = collectionView.dequeueReusableSupplementaryView(
+                ofKind: UICollectionView.elementKindSectionHeader,
+                withReuseIdentifier: CollectionHeaderView.className,
+                for: indexPath
+            ) as? CollectionHeaderView
+            else {
+                return UICollectionReusableView()
+            }
+            headerView.setHeaderTitle(headerTitle: "コンテンツヘッダー")
+            return headerView
+        default:
+            return UICollectionReusableView()
         }
     }
 }

--- a/SpecialViewList/Component/CollectionViewCompositionalLayout/CollectionViewCompositionalLayoutViewController.swift
+++ b/SpecialViewList/Component/CollectionViewCompositionalLayout/CollectionViewCompositionalLayoutViewController.swift
@@ -122,6 +122,10 @@ class CollectionViewCompositionalLayoutViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.largeTitleDisplayMode = .never
+        navigationItem.rightBarButtonItem = .createCloseBarButtonItem { [weak self] _ in
+            guard let self else { return }
+            self.dismiss(animated: true)
+        }
         viewModel.send(.viewDidLoad)
     }
 

--- a/SpecialViewList/Component/SpecialViewList/SpecialViewListViewController.swift
+++ b/SpecialViewList/Component/SpecialViewList/SpecialViewListViewController.swift
@@ -149,7 +149,9 @@ class SpecialViewListViewController: UIViewController {
             let controller = CollectionViewCompositionalLayoutViewController(
                 viewModel: viewModel
             )
-            present(controller, animated: true)
+            let nav = UINavigationController()
+            nav.viewControllers = [controller]
+            present(nav, animated: true)
         }
     }
 }

--- a/SpecialViewList/Extenstion/UIBarButtonItemExtension.swift
+++ b/SpecialViewList/Extenstion/UIBarButtonItemExtension.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+extension UIBarButtonItem {
+    static func createCloseBarButtonItem(
+        textColor: UIColor = .black,
+        actionHandler: @escaping UIActionHandler
+    ) -> UIBarButtonItem {
+        let xmarkImage = UIImage.sfsymbolImage(
+            sfsymbolType: .xmark,
+            pointSize: 16
+        )?.withRenderingMode(.alwaysTemplate)
+        let barButtonItem = UIBarButtonItem(
+            title: "",
+            image: xmarkImage,
+            primaryAction: UIAction(handler: actionHandler),
+            menu: nil
+        )
+        barButtonItem.tintColor = textColor
+        return barButtonItem
+    }
+}

--- a/SpecialViewList/Extenstion/UIImageExtension.swift
+++ b/SpecialViewList/Extenstion/UIImageExtension.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+extension UIImage {
+    static func sfsymbolImage(sfsymbolType: SFSymbolType) -> UIImage? {
+        UIImage(systemName: sfsymbolType.rawValue)
+    }
+
+    static func sfsymbolImage(
+        sfsymbolType: SFSymbolType,
+        pointSize: CGFloat
+    ) -> UIImage? {
+        let configuration = UIImage.SymbolConfiguration(pointSize: pointSize)
+        return UIImage(
+            systemName: sfsymbolType.rawValue,
+            withConfiguration: configuration
+        )
+    }
+}

--- a/SpecialViewList/Foundation/SFSymbolType.swift
+++ b/SpecialViewList/Foundation/SFSymbolType.swift
@@ -1,0 +1,3 @@
+enum SFSymbolType: String {
+    case xmark
+}

--- a/SpecialViewList/Foundation/Views/CollectionView/CollectionHeaderView.swift
+++ b/SpecialViewList/Foundation/Views/CollectionView/CollectionHeaderView.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+final class CollectionHeaderView: UICollectionReusableView {
+    
+    @IBOutlet weak var headerLabel: UILabel!
+    
+    func setHeaderTitle(headerTitle: String) {
+        headerLabel.text = headerTitle
+    }
+}

--- a/SpecialViewList/Foundation/Views/CollectionView/CollectionHeaderView.xib
+++ b/SpecialViewList/Foundation/Views/CollectionView/CollectionHeaderView.xib
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="CollectionHeaderView" customModule="SpecialViewList" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="56"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xn5-qv-luA">
+                    <rect key="frame" x="0.0" y="0.0" width="393" height="56"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Vt0-Fc-jEM">
+                            <rect key="frame" x="16" y="16" width="361" height="24"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="💡" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FIO-d2-bT7">
+                                    <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="24" id="MV0-dp-FCA"/>
+                                        <constraint firstAttribute="height" constant="24" id="S7K-GV-Z4f"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ヘッダー" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fgN-bM-z1i">
+                                    <rect key="frame" x="28" y="0.0" width="333" height="24"/>
+                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="Vt0-Fc-jEM" secondAttribute="trailing" constant="16" id="PXc-OE-nBg"/>
+                        <constraint firstItem="Vt0-Fc-jEM" firstAttribute="leading" secondItem="xn5-qv-luA" secondAttribute="leading" constant="16" id="S4k-Nn-jxC"/>
+                        <constraint firstAttribute="bottom" secondItem="Vt0-Fc-jEM" secondAttribute="bottom" constant="16" id="gOm-iu-SFp"/>
+                        <constraint firstItem="Vt0-Fc-jEM" firstAttribute="top" secondItem="xn5-qv-luA" secondAttribute="top" constant="16" id="qTM-Ad-A7B"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="xn5-qv-luA" secondAttribute="trailing" id="LUW-Ej-YOx"/>
+                <constraint firstItem="xn5-qv-luA" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="gF5-cG-QnB"/>
+                <constraint firstAttribute="bottom" secondItem="xn5-qv-luA" secondAttribute="bottom" id="ivz-JK-d6H"/>
+                <constraint firstItem="xn5-qv-luA" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="rbz-fh-V68"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="headerLabel" destination="fgN-bM-z1i" id="FAd-01-5j9"/>
+            </connections>
+            <point key="canvasLocation" x="-118.32061068702289" y="138.73239436619718"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
# 概要
- UICollectionViewCompositionalLayoutを用いたCollectionViewのHeaderを実装
- ナビゲーションの閉じるボタンのExtensionの追加と実装

## スクショ
<img src="https://user-images.githubusercontent.com/22518469/200310209-17bc0566-3a1d-4aba-8dc4-2099529db4b2.png" width="300">
