### PR TITLE
Fix skip logic in AudioPlayer and rename timer observer

### DIFF
--- a/SpecialViewList/Foundation/Player/AudioPlayer.swift
+++ b/SpecialViewList/Foundation/Player/AudioPlayer.swift
@@ -44,19 +44,17 @@ class AudioPlayer: AudioPlayerProtocol {
     func updateTime(currentTime: Double) {
         audioPlayer?.currentTime = currentTime
     }
-    
+
     func skipBack() {
-        let leftTime = duration - Self.skipTime
-        audioPlayer?.currentTime -= leftTime >= Self.skipTime
-            ? Self.skipTime
-            : leftTime
+        guard let player = audioPlayer else { return }
+        let newTime = max(player.currentTime - Self.skipTime, 0)
+        player.currentTime = newTime
     }
-    
+
     func skipForward() {
-        let leftTime = duration - Self.skipTime
-        audioPlayer?.currentTime += leftTime >= Self.skipTime
-            ? Self.skipTime
-            : leftTime
+        guard let player = audioPlayer else { return }
+        let newTime = min(player.currentTime + Self.skipTime, player.duration)
+        player.currentTime = newTime
     }
 }
 

--- a/SpecialViewList/Foundation/Player/VideoPlayer.swift
+++ b/SpecialViewList/Foundation/Player/VideoPlayer.swift
@@ -43,7 +43,7 @@ class VideoPlayer: VideoPlayerProtocol, VideoPlayerControlProtocol {
         case speed200 = 2.0
     }
 
-    private var timeerObserver: Any?
+    private var timerObserver: Any?
     var delegate: VideoPlayerDelegate?
     var player: AVPlayer?
     
@@ -98,11 +98,11 @@ class VideoPlayer: VideoPlayerProtocol, VideoPlayerControlProtocol {
     func pauseAndInit() {
         player?.pause()
         player?.replaceCurrentItem(with: nil)
-        if let timeerObserver {
+        if let timerObserver {
             player?.removeTimeObserver(
-                timeerObserver
+                timerObserver
             )
-            self.timeerObserver = nil
+            self.timerObserver = nil
         }
         player = nil
         delegate = nil
@@ -148,7 +148,7 @@ class VideoPlayer: VideoPlayerProtocol, VideoPlayerControlProtocol {
             Self.timeInterval,
             preferredTimescale: Int32(NSEC_PER_SEC)
         )
-        timeerObserver = player?.addPeriodicTimeObserver(
+        timerObserver = player?.addPeriodicTimeObserver(
             forInterval: intervalTime,
             queue: nil,
             using: { [weak self] _ in


### PR DESCRIPTION
## Summary
- fix skipForward/skipBack logic in `AudioPlayer` to correctly clamp times
- rename `VideoPlayer`'s `timeerObserver` typo to `timerObserver`

## Testing
- `swift --version`